### PR TITLE
Delete specific item by owner id

### DIFF
--- a/functions/deleteItem.js
+++ b/functions/deleteItem.js
@@ -1,0 +1,116 @@
+import * as fs from "fs";
+import * as path from "path";
+import getMetadataForItem from "./getMetadataForItem.js";
+
+export default (groupId, itemId, requestedOwnerId) => {
+  try {
+    // Clean the itemId to ensure it's in the correct format
+    const cleanedItemId = itemId.includes(".") ? path.parse(itemId).name : itemId;
+    
+    // Get the metadata to verify the owner
+    const metadata = getMetadataForItem(groupId, cleanedItemId);
+    
+    if (!metadata || Object.keys(metadata).length === 0) {
+      return {
+        success: false,
+        error: "Item not found or no metadata available"
+      };
+    }
+    
+    // Verify that the requestedOwnerId matches the actual owner
+    if (metadata.uploaderId !== requestedOwnerId) {
+      return {
+        success: false,
+        error: "Owner validation failed. You can only delete items you uploaded."
+      };
+    }
+    
+    const groupPath = path.join("groups", groupId);
+    const deletedFiles = [];
+    const errors = [];
+    
+    // Define all possible files for this item
+    const filesToDelete = [
+      {
+        path: path.join(groupPath, "media", `${cleanedItemId}.jpg`),
+        type: "media"
+      },
+      {
+        path: path.join(groupPath, "thumbnails", `${cleanedItemId}.jpg`),
+        type: "thumbnail"
+      },
+      {
+        path: path.join(groupPath, "metadata", `${cleanedItemId}.json`),
+        type: "metadata"
+      },
+      {
+        path: path.join(groupPath, "reactions", `${cleanedItemId}.json`),
+        type: "reactions"
+      },
+      {
+        path: path.join(groupPath, "comments", `${cleanedItemId}.json`),
+        type: "comments"
+      }
+    ];
+    
+    // Delete each file if it exists
+    filesToDelete.forEach(({ path: filePath, type }) => {
+      try {
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath);
+          deletedFiles.push({ type, path: filePath });
+        }
+      } catch (error) {
+        errors.push({
+          type,
+          path: filePath,
+          error: error.message
+        });
+      }
+    });
+    
+    // Also remove from unread items for all users
+    try {
+      const unreadDir = path.join(groupPath, "users", "unread");
+      if (fs.existsSync(unreadDir)) {
+        const unreadFiles = fs.readdirSync(unreadDir);
+        unreadFiles.forEach(unreadFile => {
+          try {
+            const unreadPath = path.join(unreadDir, unreadFile);
+            const unreadItems = JSON.parse(fs.readFileSync(unreadPath, "utf8"));
+            const updatedItems = unreadItems.filter(item => item !== cleanedItemId);
+            
+            if (updatedItems.length !== unreadItems.length) {
+              fs.writeFileSync(unreadPath, JSON.stringify(updatedItems, null, 2));
+            }
+          } catch (error) {
+            errors.push({
+              type: "unread cleanup",
+              path: path.join(unreadDir, unreadFile),
+              error: error.message
+            });
+          }
+        });
+      }
+    } catch (error) {
+      errors.push({
+        type: "unread cleanup",
+        error: error.message
+      });
+    }
+    
+    return {
+      success: deletedFiles.length > 0,
+      itemId: cleanedItemId,
+      ownerId: requestedOwnerId,
+      deletedFiles,
+      errors: errors.length > 0 ? errors : undefined
+    };
+    
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to delete item: ${error.message}`
+    };
+  }
+};


### PR DESCRIPTION
Add an API endpoint to delete a specific media item, ensuring only its owner can perform the deletion.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e984f07-e232-4091-90d2-0cc3cb550ba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e984f07-e232-4091-90d2-0cc3cb550ba1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

