### PR TITLE
Fix ffprobe compatibility with server

### DIFF
--- a/server.js
+++ b/server.js
@@ -244,8 +244,7 @@ const getVideoDimensions = (filePath) => {
       [
         "-v", "error",
         "-select_streams", "v:0",
-        "-show_entries", "stream=width,height",
-        "-show_entries", "stream_side_data=rotation",
+        "-show_streams",
         "-show_entries", "format_tags=rotate",
         "-of", "json",
         filePath


### PR DESCRIPTION
## Summary
- Replaces `-show_entries stream_side_data=rotation` with `-show_streams`, which works on the server's ffprobe 4.2.7
- The `stream_side_data` section only exists in ffprobe 7.x+; `-show_streams` reliably includes `side_data_list` with rotation across all versions
- Tested on server via SSH — correctly outputs width/height and rotation for .mov uploads

## Test plan
- [ ] Upload a `.mov` video and verify no ffprobe errors
- [ ] Verify portrait videos are correctly detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)